### PR TITLE
Setup custom logic before command is executed

### DIFF
--- a/EasyCommand.AspNetCore/CommandRunningConfiguration.cs
+++ b/EasyCommand.AspNetCore/CommandRunningConfiguration.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EasyCommand.AspNetCore
+{
+    public class CommandRunningConfiguration
+    {
+        internal List<Type> toRunBeforeCommands { get; set; }
+
+        public CommandRunningConfiguration()
+        {
+            toRunBeforeCommands = new List<Type>();
+        }
+
+        public void RunBeforeCommand<T>() where T : IRunBeforeCommand
+        {
+            toRunBeforeCommands.Add(typeof(T));
+        }
+    }
+}

--- a/EasyCommand.AspNetCore/ControllerBaseExtensions.cs
+++ b/EasyCommand.AspNetCore/ControllerBaseExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 
 namespace EasyCommand.AspNetCore
 {
@@ -15,6 +16,11 @@ namespace EasyCommand.AspNetCore
 
         public static async Task<TResult> ExecuteAsync<TRequest, TResult>(this object that, IAsyncAspCommand<TRequest, TResult> command)
         {
+            if (that is ControllerBase)
+            {
+                command.SetController((ControllerBase)that);
+            }
+
             await ExecuteBeforeCommand(); 
 
             return await command.ExecuteExternalAsync(default(TRequest));
@@ -22,6 +28,11 @@ namespace EasyCommand.AspNetCore
 
         public static async Task<TResult> ExecuteAsync<TRequest, TResult>(this object that, IAsyncAspCommand<TRequest, TResult> command, TRequest request)
         {
+            if (that is ControllerBase)
+            {
+                command.SetController((ControllerBase)that);
+            }
+
             await ExecuteBeforeCommand();
 
             return await command.ExecuteExternalAsync(request);

--- a/EasyCommand.AspNetCore/ControllerBaseExtensions.cs
+++ b/EasyCommand.AspNetCore/ControllerBaseExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
 
@@ -15,28 +15,32 @@ namespace EasyCommand.AspNetCore
 
         public static async Task<TResult> ExecuteAsync<TRequest, TResult>(this object that, IAsyncAspCommand<TRequest, TResult> command)
         {
-            if (that is ControllerBase)
-            {
-                command.SetController((ControllerBase)that);
-            }
+            await ExecuteBeforeCommand(); 
 
             return await command.ExecuteExternalAsync(default(TRequest));
         }
 
         public static async Task<TResult> ExecuteAsync<TRequest, TResult>(this object that, IAsyncAspCommand<TRequest, TResult> command, TRequest request)
         {
-            if (that is ControllerBase)
-            {
-                command.SetController((ControllerBase)that);
-            }
+            await ExecuteBeforeCommand();
 
             return await command.ExecuteExternalAsync(request);
         }
 
-        public static TCommand Command<TCommand>(this object that)
-            where TCommand : IAsyncCommand
+        public static TCommand Command<TCommand>(this object that) where TCommand : IAsyncCommand
         {
             return Scope.ServiceProvider.GetService<TCommand>();
+        }
+
+        private static async Task ExecuteBeforeCommand()
+        {
+            var allExecutingBefore = Scope.ServiceProvider.GetServices<IRunBeforeCommand>()?.ToArray() ?? new IRunBeforeCommand[0];
+
+            if (allExecutingBefore.Any())
+            {
+                await Task.WhenAll(allExecutingBefore.Select(executingBefore =>
+                    executingBefore.BeforeExecutionOfCommand()));
+            }
         }
     }
 }

--- a/EasyCommand.AspNetCore/IRunBeforeCommand.cs
+++ b/EasyCommand.AspNetCore/IRunBeforeCommand.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace EasyCommand.AspNetCore
+{
+    public interface IRunBeforeCommand
+    {
+        Task BeforeExecutionOfCommand();
+    }
+}

--- a/EasyCommand.Examples.AspNetCore/Commands/CommandLogger.cs
+++ b/EasyCommand.Examples.AspNetCore/Commands/CommandLogger.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Threading.Tasks;
+using EasyCommand.AspNetCore;
+
+namespace EasyCommand.Examples.AspNetCore.Commands
+{
+    public class CommandLogger : IRunBeforeCommand
+    {
+        public Task BeforeExecutionOfCommand()
+        {
+            Console.WriteLine("Running before");
+            return Task.CompletedTask;
+;        }
+    }
+}

--- a/EasyCommand.Examples.AspNetCore/Startup.cs
+++ b/EasyCommand.Examples.AspNetCore/Startup.cs
@@ -1,16 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using EasyCommand.AspNetCore;
+﻿using EasyCommand.AspNetCore;
+using EasyCommand.Examples.AspNetCore.Commands;
 using EasyCommand.Examples.AspNetCore.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace EasyCommand.Examples.AspNetCore
 {
@@ -30,7 +25,7 @@ namespace EasyCommand.Examples.AspNetCore
 
             services.AddTransient<IRandomService, RandomService>();
 
-            services.AddEasyCommand(this);
+            services.AddEasyCommand(c=>c.RunBeforeCommand<CommandLogger>());
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Resolves #2 
also by refactoring resolves #1 
This is the ability to setup custom logic that will run before any command is executed. This is general for all commands and is bound to dependency inject therefore it resides in the asp extension library not the base. 

Users will need to setup what they want to run in the Startup.cs when they add EasyCommand. For instance
```
services.AddEasyCommand(c=>c.RunBeforeCommand<CommandLogger>());
```
this is an example of how this will be done. This was chosen at it provides the most granular level of control for users who may want to turn on/off features to run before commands depending on environment (or other things such as logging only in debug);
