### PR TITLE
Fix broken test SuccessfullyRegistersCustomHandler

### DIFF
--- a/EasyCommand.AspNetCore.Tests/EasyCommandServiceCollectionExtensionsTests.cs
+++ b/EasyCommand.AspNetCore.Tests/EasyCommandServiceCollectionExtensionsTests.cs
@@ -39,7 +39,7 @@ namespace EasyCommand.AspNetCore.Tests
             var services = CreateServiceProvider(
                     t => t.AddEasyCommand(c=>c.AddControllerCommandHandler<ExampleHandler>()));
 
-            var runBeforeComamnds = services.GetServices<IAsyncAspCommandHandler>();
+            var runBeforeComamnds = services.GetServices<ExampleHandler>();
 
             Assert.NotNull(runBeforeComamnds);
             Assert.Contains(runBeforeComamnds, t => t.GetType() == typeof(ExampleHandler));


### PR DESCRIPTION
Update broken test to validate on type not interfaces as custom handlers are not registered against the interface type but their actual type